### PR TITLE
feat: add the tree cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,17 @@ $ trivy referrer get localhost:5002/demo:app --digest 5b0306d | head
         "vendor": "aquasecurity",
 
 ```
+
+### Listing referrers recursively
+
+```
+$ trivy referrer tree localhost:500/demo:app
+Subject: localhost:5002/demo:app
+
+a5cb013
+├── 5b0306d: application/vnd.cyclonedx+json
+│   └── c248e29: application/vnd.cncf.notary.signature
+├── 771989f: application/spdx+json
+├── 83542d1: application/sarif+json
+└── 8b9f058: application/sarif+json
+```

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaW
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "referrer"
 repository: github.com/aquasecurity/trivy-plugin-referrer
-version: "0.1.1"
+version: "0.1.2"
 usage: Put referrers to OCI registry
 description: |-
   A Trivy plugin for OCI referrers
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.1/trivy_plugin_referrer_0.1.1_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_macOS-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.1/trivy_plugin_referrer_0.1.1_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_macOS-ARM64.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.1/trivy_plugin_referrer_0.1.1_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_Linux-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.1/trivy_plugin_referrer_0.1.1_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_Linux-ARM64.tar.gz
     bin: ./referrer

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/xlab/treeprint"
+)
+
+var digestFull = false
+
+func FormatDigest(digest string) string {
+	if digestFull {
+		return digest
+	}
+	return strings.TrimPrefix(digest, "sha256:")[:7]
+}
+
+func treeReferrers(w io.Writer, opts treeOptions) error {
+
+	if opts.Full {
+		digestFull = true
+	}
+
+	targetDigest, err := fetchTargetDigest(opts.Subject)
+	if err != nil {
+		return fmt.Errorf("error getting digest: %w", err)
+	}
+
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+
+	writer.Write([]byte(fmt.Sprintf("Subject: %s\n\n", opts.Subject)))
+
+	tree := treeprint.NewWithRoot(FormatDigest(targetDigest.DigestStr()))
+	if err := recurseReferrers(tree, targetDigest); err != nil {
+		return fmt.Errorf("error writing referrers: %w", err)
+	}
+
+	writer.Write([]byte(tree.String()))
+
+	return nil
+}
+
+func recurseReferrers(root treeprint.Tree, digest name.Digest) error {
+	index, err := remote.Referrers(digest, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("error fetching referrers: %w", err)
+	}
+
+	if len(index.Manifests) == 0 {
+		return nil
+	}
+
+	for _, manifest := range index.Manifests {
+		node := root.AddBranch(fmt.Sprintf("%s: %s", FormatDigest(manifest.Digest.String()), manifest.ArtifactType))
+
+		d, err := name.NewDigest(
+			fmt.Sprintf("%s/%s@%s", digest.RegistryStr(), digest.RepositoryStr(), manifest.Digest.String()),
+		)
+		if err != nil {
+			return fmt.Errorf("error creating digest: %w", err)
+		}
+
+		if err := recurseReferrers(node, d); err != nil {
+			return fmt.Errorf("error writing referrers: %w", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Add the tree command.

```
$ trivy referrer tree localhost:500/demo:app
Subject: localhost:5002/demo:app
a5cb013
├── 5b0306d: application/vnd.cyclonedx+json
│   └── c248e29: application/vnd.cncf.notary.signature
├── 771989f: application/spdx+json
├── 83542d1: application/sarif+json
└── 8b9f058: application/sarif+json
```

If you want the full digests, use `--full` option.
```
> ./trivy-plugin-referrer tree localhost:5002/demo2:app --full
Subject: localhost:5002/demo2:app

sha256:a5cb013fa8479e343bfc8505163a53c68d344813576b6efb602828f34d80843d
├── sha256:5b0306dbbe8252a9efaa7a5177d5ae313441aa85c3d994b2183726303fe52101: application/vnd.cyclonedx+json
│   └── sha256:c248e29c1a474fad331a9c16e51242aaf2f06bc625b5934602fcba01ef15be0b: application/vnd.cncf.notary.signature
├── sha256:771989fa05d016a3417790ee1c644972e0937de22e484f8ec51167e07ce85286: application/spdx+json
├── sha256:83542d11b4e7bc347c728498e050e62b54a1bec3485bad6da2d1a70932259c6f: application/sarif+json
└── sha256:8b9f058b8b4ece43b90a00fb423e336fd8f2e6f63edf87e206fff3c5155764ea: application/sarif+json
```