### PR TITLE
feat: add the created-by annotation when putting the referrer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Referrers:
   MediaType:                                 application/vnd.oci.image.manifest.v1+json
   ArtifactType:                              application/vnd.cyclonedx+json
   Annotations:                               
-    created:                                 trivy
+    created-by:                              trivy
     org.opencontainers.artifact.created:     2023-04-11T19:21:29+09:00
     org.opencontainers.artifact.description: CycloneDX JSON SBOM
 
 
 $ trivy referrer list localhost:5002/demo:app --format table
-DIGEST  TYPE      ANNOTATIONS    DESCRIPTION         CREATED
-5b0306d cyclonedx created=trivy  CycloneDX JSON SBOM 22 hours ago
-771989f spdx-json created=trivy  SPDX JSON SBOM      22 hours ago
-83542d1 sarif                    SARIF               18 hours ago
-8b9f058 sarif                    SARIF               15 hours ago
+DIGEST  TYPE      ANNOTATIONS       DESCRIPTION         CREATED
+5b0306d cyclonedx created-by=trivy  CycloneDX JSON SBOM 22 hours ago
+771989f spdx-json created-by=trivy  SPDX JSON SBOM      22 hours ago
+83542d1 sarif     created-by=trivy  SARIF               18 hours ago
+8b9f058 sarif     created-by=trivy  SARIF               15 hours ago
 ```
 
 ### Getting the artifact

--- a/put.go
+++ b/put.go
@@ -73,6 +73,14 @@ func (r *referrer) Tag(img v1.Image) (name.Reference, error) {
 	return tag, nil
 }
 
+func newAnnotations(description string) map[string]string {
+	return map[string]string{
+		annotationKeyDescription:       description,
+		annotationKeyCreated:           time.Now().Format(time.RFC3339),
+		customAnnotationKeyDescription: "trivy",
+	}
+}
+
 func putReferrer(r io.Reader, opts putOptions) error {
 	ref, err := referrerFromReader(r, opts)
 	if err != nil {
@@ -169,10 +177,7 @@ func tryReferrerFromSBOM(r io.Reader, opts putOptions) (referrer, error) {
 			}
 		}
 
-		anns = map[string]string{
-			annotationKeyDescription: "CycloneDX JSON SBOM",
-			annotationKeyCreated:     time.Now().Format(time.RFC3339),
-		}
+		anns = newAnnotations("CycloneDX JSON SBOM")
 		mediaType = mediaKeyCycloneDX
 
 	case sbom.FormatSPDXJSON:
@@ -188,10 +193,7 @@ func tryReferrerFromSBOM(r io.Reader, opts putOptions) (referrer, error) {
 			}
 		}
 
-		anns = map[string]string{
-			annotationKeyDescription: "SPDX JSON SBOM",
-			annotationKeyCreated:     time.Now().Format(time.RFC3339),
-		}
+		anns = newAnnotations("SPDX JSON SBOM")
 		mediaType = mediaKeySPDX
 
 	default:
@@ -263,10 +265,7 @@ func tryReferrerFromSarif(r io.Reader, opts putOptions) (referrer, error) {
 	}
 	log.Logger.Infof("SARIF detected")
 
-	anns := map[string]string{
-		annotationKeyDescription: "SARIF",
-		annotationKeyCreated:     time.Now().Format(time.RFC3339),
-	}
+	anns := newAnnotations("SARIF")
 	anns = lo.Assign(anns, opts.Annotations)
 
 	return referrer{
@@ -308,10 +307,7 @@ func tryReferrerFromVulnerability(r io.Reader, opts putOptions) (referrer, error
 
 	log.Logger.Infof("Cosign vulnerability data detected")
 
-	anns := map[string]string{
-		annotationKeyDescription: "Vulnerability Scan Report",
-		annotationKeyCreated:     time.Now().Format(time.RFC3339),
-	}
+	anns := newAnnotations("Cosign Vulnerability Data")
 	anns = lo.Assign(anns, opts.Annotations)
 
 	return referrer{

--- a/types.go
+++ b/types.go
@@ -7,6 +7,8 @@ const (
 	annotationKeyCreated     = "org.opencontainers.artifact.created"
 	annotationKeyDescription = "org.opencontainers.artifact.description"
 
+	customAnnotationKeyDescription = "created-by"
+
 	// Use a Media Type registered with IANA.
 	// ref. https://github.com/opencontainers/image-spec/blob/dd7fd714f5406d39db5fd0602a0e6090929dc85e/artifact.md#artifact-manifest-property-descriptions
 	// ref. https://www.iana.org/assignments/media-types/media-types.xhtml


### PR DESCRIPTION
## Descritpion

Add the created-by annotation when putting the referrer.

```
$ trivy image -q -f cyclonedx  localhost:5002/demo-referrers-2023:app | ./trivy-plugin-referrer put

$ ./trivy-plugin-referrer list  localhost:5002/demo-referrers-2023:app --filter-annotation created-by=trivy
Subject:                                     localhost:5002/demo-referrers-2023:app
Referrers:                                    
  Digest:                                    sha256:83ad24b36d1d2244e5375298a65b5ecb133b363695f162d869088fc7689e95ae
  Reference:                                 localhost:5002/demo-referrers-2023@sha256:83ad24b36d1d2244e5375298a65b5ecb133b363695f162d869088fc7689e95ae
  MediaType:                                 application/vnd.oci.image.manifest.v1+json
  ArtifactType:                              application/vnd.cyclonedx+json
  Annotations:                               
    created-by:                              trivy
    org.opencontainers.artifact.created:     2023-04-12T23:31:32+09:00
    org.opencontainers.artifact.description: CycloneDX JSON SBOM

$ ./trivy-plugin-referrer list localhost:5002/demo3:app --format table
DIGEST  TYPE      ANNOTATIONS       DESCRIPTION         CREATED
736bb30 cyclonedx created-by=trivy  CycloneDX JSON SBOM 13 minutes ago
287a9d9 spdx-json created-by=trivy  SPDX JSON SBOM      13 minutes ago
be7cd3e sarif     created-by=trivy  SARIF               12 minutes ago⏎    
```