### PR TITLE
fix: fix listing referrers

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "referrer"
 repository: github.com/aquasecurity/trivy-plugin-referrer
-version: "0.1.2"
+version: "0.1.3"
 usage: Put referrers to OCI registry
 description: |-
   A Trivy plugin for OCI referrers
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.3/trivy_plugin_referrer_0.1.3_macOS-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.3/trivy_plugin_referrer_0.1.3_macOS-ARM64.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.3/trivy_plugin_referrer_0.1.3_Linux-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.2/trivy_plugin_referrer_0.1.2_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.3/trivy_plugin_referrer_0.1.3_Linux-ARM64.tar.gz
     bin: ./referrer


### PR DESCRIPTION
## Descritpion

When the subject has no referrers, OCI registries that do not support referrers API return an error instead of an empty referrers list.
Add support for listing referrers for OCI registries that do not support the referrer API.


before
```
> trivy referrer tree localhost:5001/demo-referrers-2023:app
Subject: localhost:5001/demo-referrers-2023:app

Error: error getting referrer: error writing referrers: error writing referrers: error fetching referrers: GET http://localhost:5001/v2/demo-referrers-2023/manifests/sha256-bc954b44bf47139ac65d4bb6b7ccfd352c497136740ff60328c630316dc7a414: MANIFEST_UNKNOWN: manifest unknown; map[Tag:sha256-bc954b44bf47139ac65d4bb6b7ccfd352c497136740ff60328c630316dc7a414]

```

after
```
> ./trivy-plugin-referrer tree localhost:5001/demo-referrers-2023:app
Subject: localhost:5001/demo-referrers-2023:app

a5cb013
├── bc954b4: application/spdx+json
└── f244266: application/vnd.cyclonedx+json
    └── 27aa6fa: application/vnd.cncf.notary.signature

```

## Cause

The go-containerregistry is returning an error directly before performing exception handling when it falls back.

https://github.com/google/go-containerregistry/blob/1cfe1fc25f233b40aa5d3b0edd572ed5c3f854c9/pkg/v1/remote/descriptor.go#L274-L282