### PR TITLE
feat: add plugin.yaml file to release

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -29,3 +29,4 @@ archives:
       - README.md
       - LICENSE
       - contrib/*.tpl
+      - plugin.yaml


### PR DESCRIPTION
The release archive does not contain the `plugin.yaml` file which prevents users from downloading the archive and installing the plugin offline.

This PR aims at adding the `plugin.yaml` file to the release archive.