### PR TITLE
chore: release v0.1.5

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "referrer"
 repository: github.com/aquasecurity/trivy-plugin-referrer
-version: "0.1.4"
+version: "0.1.5"
 usage: Put referrers to OCI registry
 description: |-
   A Trivy plugin for OCI referrers
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.4/trivy_plugin_referrer_0.1.4_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.5/trivy_plugin_referrer_0.1.5_macOS-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.4/trivy_plugin_referrer_0.1.4_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.5/trivy_plugin_referrer_0.1.5_macOS-ARM64.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.4/trivy_plugin_referrer_0.1.4_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.5/trivy_plugin_referrer_0.1.5_Linux-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.4/trivy_plugin_referrer_0.1.4_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.1.5/trivy_plugin_referrer_0.1.5_Linux-ARM64.tar.gz
     bin: ./referrer


### PR DESCRIPTION
I will release the current main branch. It includes the solution(https://github.com/aquasecurity/trivy-plugin-referrer/pull/9) to the issue(https://github.com/aquasecurity/trivy-plugin-referrer/issues/11).




