### PR TITLE
fix: Fix flag binding issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,11 +179,11 @@ func main() {
 		},
 	}
 	getCmd.Flags().StringP("type", "", "", "artifact type (cyclonedx, spdx-json, sarif, cosign-vuln)")
-	viper.BindPFlag("type", putCmd.Flags().Lookup("type"))
+	viper.BindPFlag("type", getCmd.Flags().Lookup("type"))
 	getCmd.Flags().StringP("digest", "", "", "referrer digest. If the length of the digest is only partial, search for artifacts with matching prefixes")
-	viper.BindPFlag("digest", putCmd.Flags().Lookup("digest"))
+	viper.BindPFlag("digest", getCmd.Flags().Lookup("digest"))
 	getCmd.Flags().StringP("output", "o", "", "output file name")
-	viper.BindPFlag("output", putCmd.Flags().Lookup("output"))
+	viper.BindPFlag("output", getCmd.Flags().Lookup("output"))
 
 	rootCmd.AddCommand(getCmd)
 
@@ -275,9 +275,9 @@ func main() {
 		},
 	}
 	treeCmd.Flags().BoolP("full", "", false, "output the full digests")
-	viper.BindPFlag("full", listCmd.Flags().Lookup("full"))
+	viper.BindPFlag("full", treeCmd.Flags().Lookup("full"))
 	treeCmd.Flags().StringP("output", "o", "", "output file name")
-	viper.BindPFlag("output", listCmd.Flags().Lookup("output"))
+	viper.BindPFlag("output", treeCmd.Flags().Lookup("output"))
 
 	rootCmd.AddCommand(treeCmd)
 


### PR DESCRIPTION
Fixed errors in the variable specification when implementing env support(https://github.com/aquasecurity/trivy-plugin-referrer/pull/14). This issue was causing options not to be set correctly. 

**get command**

before
```console
> ./trivy-plugin-referrer get localhost:5002/demo7:app  --digest a3dad722d3abc495da8f5e081de12685f22bc0e23120e3943298a5b7360cec16
Error: error getting referrer: error getting artifact digest: either digest or type must be specified
Usage:
   get YOUR_IMAGE [flags]

Examples:
  $ trivy referrer get --type cyclonedx YOUR_IMAGE
  $ trivy referrer get --digest DIGEST YOUR_IMAGE

Flags:
      --digest string   referrer digest. If the length of the digest is only partial, search for artifacts with matching prefixes
  -h, --help            help for get
  -o, --output string   output file name
      --type string     artifact type (cyclonedx, spdx-json, sarif, cosign-vuln)

Global Flags:
  -d, --debug      debug mode
      --insecure   allow insecure server connections
  -q, --quiet      suppress log output

2023-09-02T22:57:31.407+0900    FATAL   error getting referrer: error getting artifact digest: either digest or type must be specified
```

after
```console
> ./trivy-plugin-referrer get localhost:5002/demo7:app  --digest a3dad722d3abc495da8f5e081de12685f22bc0e23120e3943298a5b7360cec16 | head
{ 
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:1c13d7a9-9624-4153-9823-ab8834979b34",
  "version": 1,
  "metadata": {
    "timestamp": "2023-04-13T13:05:18+00:00",
    "tools": [
      {
        "vendor": "aquasecurity",
```

**tree command**

before
```console
> ./trivy-plugin-referrer  tree localhost:5002/demo7:app --full
Subject: localhost:5002/demo7:app

a5cb013
├── a3dad72: application/vnd.cyclonedx+json
├── 24a4534: application/spdx+json
├── c66584d: application/spdx+json
└── 54583f4: application/vnd.cncf.notary.signature
```

after
```console
> ./trivy-plugin-referrer  tree localhost:5002/demo7:app --full
Subject: localhost:5002/demo7:app

sha256:a5cb013fa8479e343bfc8505163a53c68d344813576b6efb602828f34d80843d
├── sha256:a3dad722d3abc495da8f5e081de12685f22bc0e23120e3943298a5b7360cec16: application/vnd.cyclonedx+json
├── sha256:24a4534db32949a43372c3dc9bf148494a28457df09a6676564589b7fd9f92cd: application/spdx+json
├── sha256:c66584d467a3be81ac30b79b05ab52b87934dd870d730078568cc9f200c197cc: application/spdx+json
└── sha256:54583f4230fa2342664a2c750dec1e14f531c697fa37653bb81c78a0a5588238: application/vnd.cncf.notary.signature

```