### PR TITLE
fix: add auth option to put operation

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "referrer"
 repository: github.com/aquasecurity/trivy-plugin-referrer
-version: "0.2.2"
+version: "0.2.3"
 usage: Put referrers to OCI registry
 description: |-
   A Trivy plugin for OCI referrers
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.2/trivy_plugin_referrer_0.2.2_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_macOS-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.2/trivy_plugin_referrer_0.2.2_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_macOS-ARM64.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.2/trivy_plugin_referrer_0.2.2_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_Linux-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.2/trivy_plugin_referrer_0.2.2_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_Linux-ARM64.tar.gz
     bin: ./referrer

--- a/put.go
+++ b/put.go
@@ -102,7 +102,8 @@ func putReferrer(r io.Reader, opts putOptions) error {
 
 	log.Logger.Infof("Pushing referrer to %s", tag.String())
 
-	if err = remote.Write(tag, img, ref.RemoteOptions()...); err != nil {
+	remoteOpts := append(ref.RemoteOptions(), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err = remote.Write(tag, img, remoteOpts...); err != nil {
 		return fmt.Errorf("error pushing referrer: %w", err)
 	}
 


### PR DESCRIPTION
Fix https://github.com/aquasecurity/trivy-plugin-referrer/issues/16

During the implementation of the insecure option, the put command was missing the specification for the authentication option.
https://github.com/aquasecurity/trivy-plugin-referrer/pull/15/files#diff-f7d40f84ef38661301c5ab16e6e30d20e80eca96d5b2a46ad7385bd118f56c04L102-R105

before
```console
$ trivy image -q -f cyclonedx demo.goharbor.io/test_trivy/trivy_referrer_test | ./trivy-plugin-referrer put
2023-09-02T11:20:03.259+0900trivINFOuginSBOM detected: cyclonedx-json
2023-09-02T11:20:04.355+0900    INFO    Pushing referrer to demo.goharbor.io/test_trivy/trivy_referrer_test@sha256:540faa29bc9913efd48a0f0ed3ebb76329647247d722e999fcac844f2bad5014
Error: error putting referrer: error pushing referrer: HEAD https://demo.goharbor.io/v2/test_trivy/trivy_referrer_test/manifests/sha256:540faa29bc9913efd48a0f0ed3ebb76329647247d722e999fcac844f2bad5014: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
Usage:
   put [flags]

Examples:
  trivy image -q -f cyclonedx YOUR_IMAGE | trivy referrer put
  # Put SBOM attestation
  trivy referrer put -f sbom.json

Flags:
      --annotation strings   annotations associated with the artifact (can specify multiple or separate values with commas: key1=path1,key2=path2)
  -f, --file string          file path. If a file path is not specified, it will accept input from the standard input.
  -h, --help                 help for put
      --subject string       set the subject to a reference (If the value is not set, it will attempt to detect it automatically from the input)

Global Flags:
  -d, --debug      debug mode
      --insecure   allow insecure server connections
  -q, --quiet      suppress log output

2023-09-02T11:20:05.708+0900    FATAL   error putting referrer: error pushing referrer: HEAD https://demo.goharbor.io/v2/test_trivy/trivy_referrer_test/manifests/sha256:540faa29bc9913efd48a0f0ed3ebb76329647247d722e999fcac844f2bad5014: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)

$
```

aftrer
```console
$ trivy image -q -f cyclonedx demo.goharbor.io/test_trivy/trivy_referrer_test | ./trivy-plugin-referrer put
2023-09-02T22:54:30.034+0900    INFO    SBOM detected: cyclonedx-json
2023-09-02T22:54:31.200+0900    INFO    Pushing referrer to demo.goharbor.io/test_trivy/trivy_referrer_test@sha256:488e18cbc03c69758385e8f1d016e40a1b2ec3d2bec425c1b7eb55eab4bcc058

$
```