### PR TITLE
chore: release v0.3.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "referrer"
 repository: github.com/aquasecurity/trivy-plugin-referrer
-version: "0.2.3"
+version: "0.3.0"
 usage: Put referrers to OCI registry
 description: |-
   A Trivy plugin for OCI referrers
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.0/trivy_plugin_referrer_0.3.0_macOS-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.0/trivy_plugin_referrer_0.3.0_macOS-ARM64.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.0/trivy_plugin_referrer_0.3.0_Linux-64bit.tar.gz
     bin: ./referrer
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.2.3/trivy_plugin_referrer_0.2.3_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.0/trivy_plugin_referrer_0.3.0_Linux-ARM64.tar.gz
     bin: ./referrer


### PR DESCRIPTION
Release these PRs.
- https://github.com/aquasecurity/trivy-plugin-referrer/pull/25
- https://github.com/aquasecurity/trivy-plugin-referrer/pull/26